### PR TITLE
Fix for conflicting method names 

### DIFF
--- a/lib/genspec/matchers.rb
+++ b/lib/genspec/matchers.rb
@@ -12,7 +12,7 @@ module GenSpec
     #   subject.should generate(:file, ...)
     #   subject.should generate("vendor/plugins/will_paginate/init.rb")
     #
-    def generate(kind = nil, *args, &block)
+    def generate_file(kind = nil, *args, &block)
       if kind.kind_of?(Symbol)
         # subject.should generate(:file, ...)
         call_action(kind, *args, &block)
@@ -29,13 +29,13 @@ module GenSpec
     # Example:
     #   subject.should delete("path/to/file")
     #
-    def delete(filename)
+    def delete_file(filename)
       within_source_root do
         FileUtils.mkdir_p File.dirname(filename)
         FileUtils.touch   filename
       end
       
-      generate { File.should_not exist(filename) }
+      generate_file { File.should_not exist(filename) }
     end
     
     # ex:

--- a/spec/generators/migration_spec.rb
+++ b/spec/generators/migration_spec.rb
@@ -4,7 +4,7 @@ if defined?(Rails)
   describe :my_migration do
     it "should run migration template" do
       # bug, raising NameError: undefined local variable or method `interceptor'
-      proc { subject.should generate(:migration_template, "1", "2") }.should_not raise_error(NameError)
+      proc { subject.should generate_file(:migration_template, "1", "2") }.should_not raise_error(NameError)
     end
   end
 end

--- a/spec/generators/test_rails3_spec.rb
+++ b/spec/generators/test_rails3_spec.rb
@@ -7,7 +7,7 @@ describe :test_rails3 do
   
   it "should modify Gemfile" do
     out = ""
-    subject.should generate {
+    subject.should generate_file {
       File.read("Gemfile").strip.should_not be_blank
       out.concat File.read("Gemfile")
     }
@@ -16,8 +16,8 @@ describe :test_rails3 do
   
   context "with no options or arguments" do
     it "should generate a file called default_file" do
-      subject.should     generate("default_file")
-      subject.should_not generate("some_other_file")
+      subject.should     generate_file("default_file")
+      subject.should_not generate_file("some_other_file")
       
       subject.should     call_action(:create_file)
       subject.should     call_action(:create_file, "default_file")
@@ -29,14 +29,14 @@ describe :test_rails3 do
     end
     
     it "should generate a file with specific content" do
-      subject.should generate("default_file") { |content| content.should == "content!" }
-      subject.should generate("default_file") { |content| content.should_not == "!content" }
-      subject.should_not generate("some_other_file")
+      subject.should generate_file("default_file") { |content| content.should == "content!" }
+      subject.should generate_file("default_file") { |content| content.should_not == "!content" }
+      subject.should_not generate_file("some_other_file")
     end
     
     it "should generate a template called 'default_template'" do
-      subject.should generate(:template)
-      subject.should generate(:template, 'file', 'file_template')
+      subject.should generate_file(:template)
+      subject.should generate_file(:template, 'file', 'file_template')
     end
     
     it "should output 'create    file'" do
@@ -44,10 +44,10 @@ describe :test_rails3 do
     end
     
     it "shoud generate a directory called 'a_directory'" do
-      subject.should     generate(:empty_directory)
-      subject.should     generate(:empty_directory, "a_directory")
-      subject.should     generate("a_directory")
-      subject.should_not generate(:empty_directory, 'another_directory')
+      subject.should     generate_file(:empty_directory)
+      subject.should     generate_file(:empty_directory, "a_directory")
+      subject.should     generate_file("a_directory")
+      subject.should_not generate_file(:empty_directory, 'another_directory')
       subject.should     empty_directory("a_directory")
       subject.should_not empty_directory("another_directory")
     end
@@ -76,23 +76,23 @@ describe :test_rails3 do
     with_args :test_arg
     
     it "should generate file 'test_arg'" do
-      subject.should generate('test_arg')
+      subject.should generate_file('test_arg')
     end
   end
 
   with_args :test_arg do
     it "should generate file 'test_arg'" do
-      subject.should generate('test_arg')
+      subject.should generate_file('test_arg')
     end
     
     it "should not generate template_name" do
       # because that option hasn't been given in this context.
-      subject.should_not generate('template_name')
+      subject.should_not generate_file('template_name')
     end
     
     with_generator_options :behavior => :revoke do
       it "should delete file 'test_arg'" do
-        subject.should generate {
+        subject.should generate_file {
           File.should_not exist("test_arg")
         }
       end
@@ -100,18 +100,18 @@ describe :test_rails3 do
       # demonstrate use of the `delete` matcher, which is equivalent to
       # above:
       it "should destroy file 'test_arg'" do
-        subject.should delete("test_arg")
+        subject.should delete_file("test_arg")
       end
     end
     
     # ...and a test of nested args
     with_args "template_name" do
       it "should generate file 'test_arg'" do
-        subject.should generate('test_arg')
+        subject.should generate_file('test_arg')
       end
 
       it "should generate file 'template_name'" do
-        subject.should generate("template_name")
+        subject.should generate_file("template_name")
       end
     end
   end

--- a/spec/lib/genspec_spec.rb
+++ b/spec/lib/genspec_spec.rb
@@ -11,7 +11,7 @@ describe GenSpec do
   
     it "should generate files in generation root" do
       within_source_root { Dir[File.join(GenSpec.root, '**/*')].should_not be_empty }
-      subject.should generate("a_directory")
+      subject.should generate_file("a_directory")
     end
   end
 end


### PR DESCRIPTION
Hi there,

it looks like the "generate" matcher conflicts with the method by the same name provided by FactoryGirl, while the "delete" matcher conflicts with the "delete" method used when testing requests with the delete HTTP verb in controller specs.

I have renamed these methods to "generate_file" and "delete_file" for this reason. 
