### PR TITLE
Allow base class

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,6 +40,14 @@ A basic generator spec might look something like this:
       end
     end
   end
+
+=== Checking an engine
+
+You may need to specify a base class, particularly if you are testing a Rails engine:
+
+  describe "base_class:custom_controller" do
+    ...
+  end
   
 === Checking Generated Files
 

--- a/lib/genspec/matchers/base.rb
+++ b/lib/genspec/matchers/base.rb
@@ -20,6 +20,8 @@ module GenSpec
       
       def matches?(generator)
         @described = generator[:described]
+        base = nil
+        base, @described = @described.split(/:/) if @described =~ /:/
         @args = generator[:args]
         @generator_options = generator[:generator_options]
         @shell = GenSpec::Shell.new(generator[:output] || "", generator[:input] || "")
@@ -29,7 +31,7 @@ module GenSpec
           @generator = @described
         else
           if defined?(Rails)
-            @generator = Rails::Generators.find_by_namespace(@described)
+            @generator = Rails::Generators.find_by_namespace(@described, base)
           else
             @generator = Thor::Util.find_by_namespace(@described)
           end


### PR DESCRIPTION
To use genspec on a Rails engine, you need to pass the base class to `Rails::Generators.find_by_namespace`. Provided a simple means to pass it to genspec using `describe "base_class:generator_class"`. 
