### PR TITLE
Make destination root consistent with generator options

### DIFF
--- a/lib/genspec/matchers/base.rb
+++ b/lib/genspec/matchers/base.rb
@@ -37,7 +37,7 @@ module GenSpec
         
         raise "Could not find generator: #{@described.inspect}" unless @generator
         
-        inject_error_handlers! unless @generator.new.respond_to?(:invoke_with_genspec_error_handler)
+        inject_error_handlers!
         invoking
         invoke
         matched?
@@ -139,7 +139,11 @@ module GenSpec
               interceptor.error = err
               raise err
             end
-          
+          end
+        end
+
+        unless @generator.new.respond_to?(:invoke_with_genspec_error_handler)
+          no_tasks do  
             alias invoke_without_genspec_error_handler invoke
             alias invoke invoke_with_genspec_error_handler
           end

--- a/lib/genspec/matchers/base.rb
+++ b/lib/genspec/matchers/base.rb
@@ -37,7 +37,7 @@ module GenSpec
         
         raise "Could not find generator: #{@described.inspect}" unless @generator
         
-        inject_error_handlers!
+        inject_error_handlers! unless @generator.new.respond_to?(:invoke_with_genspec_error_handler)
         invoking
         invoke
         matched?

--- a/lib/genspec/matchers/base.rb
+++ b/lib/genspec/matchers/base.rb
@@ -97,12 +97,17 @@ module GenSpec
       end
       
       def mktmpdir(&block)
-        tmpdir_args = [ @described.to_s ]
-        if GenSpec.root
-          FileUtils.mkdir_p GenSpec.root
-          tmpdir_args << GenSpec.root
+        if path = @generator_options[:destination_root]
+          FileUtils.mkpath(path) unless File.directory?(path)
+          yield path
+        else
+          tmpdir_args = [ @described.to_s ]
+          if GenSpec.root
+            FileUtils.mkdir_p GenSpec.root
+            tmpdir_args << GenSpec.root
+          end
+          Dir.mktmpdir *tmpdir_args, &block
         end
-        Dir.mktmpdir *tmpdir_args, &block
       end
       
       def invoke


### PR DESCRIPTION
When I wrap tests in `with_generator_options destination_root: "/path/to/dest/root"`, all result matchers (`subject.should generate(something)`) within the block fail. This is because the matchers still set their own `@destination_root` to a temp directory, while the generator correctly runs with the options specified. This PR is meant to fix the issue.
